### PR TITLE
Fix hoes taking no damage when farming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # BlueJ files
 *.ctxt
 
+# Intellij
+.idea/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
@@ -21,3 +24,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Gradle
+.gradle/
+build/

--- a/src/main/java/no/hyp/farmingupgrade/FarmingUpgradePlugin.java
+++ b/src/main/java/no/hyp/farmingupgrade/FarmingUpgradePlugin.java
@@ -945,13 +945,15 @@ public final class FarmingUpgradePlugin extends JavaPlugin implements Listener {
     boolean damageTool(Player player, ItemStack tool, int damage) {
         boolean destroyed;
         var meta = tool.getItemMeta();
-        if (meta instanceof Damageable damageable) {
+        if (meta instanceof Damageable) {
             var damageEvent = new PlayerItemDamageEvent(player, tool, damage);
             this.getServer().getPluginManager().callEvent(damageEvent);
             if (!damageEvent.isCancelled()) {
+                ItemStack itemInMainHand = player.getInventory().getItemInMainHand();
+                Damageable damageable = (Damageable) itemInMainHand.getItemMeta();
                 var eventDamage = damageEvent.getDamage();
                 damageable.setDamage(damageable.getDamage() + eventDamage);
-                tool.setItemMeta(meta);
+                itemInMainHand.setItemMeta(damageable);
                 destroyed = damageable.getDamage() >= tool.getType().getMaxDurability();
             } else {
                 destroyed = false;


### PR DESCRIPTION
We noticed a bug on our server where a hoe would never take any damage while farming.
I debugged the code and it seems setting the damage was not working.
The object the damage was set on was not actually the one anymore that was inside the inventory. I'm not sure what causes this. Maybe sending out the damage event somehow reinitializes the inventory.

I fixed it by retrieving the itemInMainHand right before altering the damage. This way I had the correct object to alter. 